### PR TITLE
Fixed 4: Fix Snackbar Behavior to Reflect API Load State

### DIFF
--- a/lib/exceptions/word_not_found_exception.dart
+++ b/lib/exceptions/word_not_found_exception.dart
@@ -1,0 +1,7 @@
+class WordNotFoundException implements Exception {
+  final String message;
+  WordNotFoundException({this.message = 'Requested word was not found.'});
+
+  @override
+  String toString() => 'WordNotFoundException: $message';
+}

--- a/lib/services/fetch_words_respository_service.dart
+++ b/lib/services/fetch_words_respository_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_dictionary/exceptions/word_not_found_exception.dart';
 import 'package:flutter_dictionary/models/word_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart';
@@ -18,8 +19,11 @@ class FetchWordsRepositoryServiceImpl implements FetchWordsRepositoryService {
     final response = await client.get(Uri.https(
         'api.dictionaryapi.dev', 'api/v2/entries/' + language + '/' + word));
 
-    final data = fromJson(response.body);
-
-    return data;
+    if (response.statusCode == 404) {
+      throw WordNotFoundException();
+    } else {
+      final data = fromJson(response.body);
+      return data;
+    }
   }
 }


### PR DESCRIPTION


# Update Documentation

## Description

Fixes #4 Fix loading snackbar indefinitely while searching for a new word until found

---

## Changes Made


- Added exception to exit when api returns 404 status
- Snackbar loads until the new word is found indefinitely until error arises
- LoadingSnackbar is removed as soon as word is found
- LoadingSnackbar exits with WordNotFoundSnackbar when api returns status code 404

# Screen Recording

https://github.com/danger-ahead/flutter_dictionary/assets/113239561/09decc93-c266-4b58-a10c-406f753b4e15

---

## Testing

- With slow internet
- Wrong words

### Test Results:

- Test 1: Loads until api is unreachable or word is wrong
- Test 2: exits with Snackbar

---

## Checklist

- [x] Fixes #4 
- [x] Tested on real device (Android12)
- [x] Ran dart format 

---

